### PR TITLE
feat: Use grpcs with server certificate if `ssl_server_certificate` is set

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,10 +18,12 @@ set(CMAKE_CXX_VISIBILITY_PRESET hidden)
 if(NGX_OTEL_FETCH_DEPS)
     include(FetchContent)
 
+    set(ABSL_ENABLE_INSTALL ON)
+
     FetchContent_Declare(
         grpc
         GIT_REPOSITORY https://github.com/grpc/grpc
-        GIT_TAG        18dda3c586b2607d8daead6b97922e59d867bb7d # v1.46.6
+        GIT_TAG        0417b882aa7abc1512f534e56f9cd97c557bb68f # v1.58.0
         GIT_SUBMODULES third_party/protobuf third_party/abseil-cpp
         GIT_SHALLOW    ON)
 
@@ -35,7 +37,7 @@ if(NGX_OTEL_FETCH_DEPS)
     FetchContent_Declare(
         otelcpp
         GIT_REPOSITORY https://github.com/open-telemetry/opentelemetry-cpp
-        GIT_TAG        57bf8c2b0e85215a61602f559522d08caa4d2fb8 # v1.8.1
+        GIT_TAG        11d5d9e0d8fd8ba876c8994714cc2647479b6574 # v1.11.0
         GIT_SUBMODULES third_party/opentelemetry-proto
         GIT_SHALLOW    ON)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,7 +18,18 @@ set(CMAKE_CXX_VISIBILITY_PRESET hidden)
 if(NGX_OTEL_FETCH_DEPS)
     include(FetchContent)
 
+    set(ABSL_PROPAGATE_CXX_STD ON)
+    set(ABSL_USE_STATIC_LIBS ON)
     set(ABSL_ENABLE_INSTALL ON)
+    FetchContent_Declare(
+      absl
+      GIT_REPOSITORY https://github.com/abseil/abseil-cpp.git
+      GIT_TAG        origin/master
+      OVERRIDE_FIND_PACKAGE
+    )
+    # FetchContent_MakeAvailable(absl)
+    # set(ABSL_ENABLE_INSTALL ON)
+    # find_package(absl REQUIRED)
 
     FetchContent_Declare(
         grpc

--- a/src/batch_exporter.hpp
+++ b/src/batch_exporter.hpp
@@ -111,9 +111,9 @@ public:
         int attrSize{0};
     };
 
-    BatchExporter(StrView target,
+    BatchExporter(StrView target, StrView sslServerCertificate,
             size_t batchSize, size_t batchCount, StrView serviceName) :
-        batchSize(batchSize), client(std::string(target))
+        batchSize(batchSize), client(std::string(target), std::string(sslServerCertificate))
     {
         free.reserve(batchCount);
         while (batchCount-- > 0) {


### PR DESCRIPTION
* Update grpc to v1.58.0
* Update open telemetry sdk to v1.11.0
* Enable tls encryption if the `ssl_server_certificate` parameter is set