### PR TITLE
fix: Allow also no encryption for testing

### DIFF
--- a/src/trace_service_client.hpp
+++ b/src/trace_service_client.hpp
@@ -22,7 +22,7 @@ public:
     TraceServiceClient(const std::string& target, const std::string& sslServerCertificate)
     {
         auto creds = grpc::InsecureChannelCredentials(); // no cacert_path
-        if (!sslServerCertificate.empty()) {
+        if (!sslServerCertificate.empty() && sslServerCertificate != "none") {
             grpc::SslCredentialsOptions options = {
                 readFile(sslServerCertificate),
                 "",


### PR DESCRIPTION
I could not manage to set the certificate to be empty in all cases and needed  a way to explicitly set "none" to avoid the ssl layer.